### PR TITLE
Use scheduleUpdate() instead of update() for performance

### DIFF
--- a/src/component/popper.js.vue
+++ b/src/component/popper.js.vue
@@ -289,7 +289,7 @@
       },
 
       updatePopper() {
-        this.popperJS ? this.popperJS.update() : this.createPopper();
+        this.popperJS ? this.popperJS.scheduleUpdate() : this.createPopper();
       },
 
       onMouseOver() {


### PR DESCRIPTION
For performance reasons, use Popper.scheduleUpdate() instead of update().

I'm using the <popper> element in a component which is rendered in a view with a v-for. When that view is rendered the entire UI hangs. By replacing the implementation of the update method with this change, the UI was rendered much quicker.