### PR TITLE
Fix for #14: Remove from body on destroy if necessary

### DIFF
--- a/src/component/popper.js.vue
+++ b/src/component/popper.js.vue
@@ -273,6 +273,10 @@
         off(document, 'click', this.handleDocumentClick);
 
         this.popperJS = null;
+
+        if (this.appendToBody) {
+          document.body.removeChild(this.popper.parentElement);
+        }
       },
 
       appendArrow(element) {


### PR DESCRIPTION
This change removes the popper's parent element from `body` if it was added there during popper creation.

I think this will fix #14 