### PR TITLE
Set showPopper to false when disabled

### DIFF
--- a/src/component/popper.js.vue
+++ b/src/component/popper.js.vue
@@ -178,6 +178,12 @@
           this[value ? 'doShow' : 'doClose']();
         },
         immediate: true
+      },
+
+      disabled(value) {
+        if (!value) {
+          this.showPopper = false
+        }
       }
     },
 


### PR DESCRIPTION
I think it makes sense to watch the `disabled` property and set `showPopper` to false whenever `disabled` changes to false. In my app, it looks weird when the popper gets reenabled and the popper shows up again without the user doing anything. I'm not 100% sure if this would be good in all cases though.