### PR TITLE
don't listen to events when not shown

### DIFF
--- a/src/component/popper.js.vue
+++ b/src/component/popper.js.vue
@@ -176,8 +176,14 @@
       showPopper(value) {
         if (value) {
           this.$emit('show', this);
+          if (this.popperJS) {
+            this.popperJS.enableEventListeners();
+          }
           this.updatePopper();
         } else {
+          if (this.popperJS) {
+            this.popperJS.disableEventListeners();
+          }
           this.$emit('hide', this);
         }
       },


### PR DESCRIPTION

Currently, scrolling performance can be degraded when lots of popper instances are used on a single page.

Here are two animation frames triggered from scroll events:

![image](https://user-images.githubusercontent.com/2367265/50058977-76d3d780-0135-11e9-9dd0-524d2820bd3f.png)

This change disables popper's event listeners when they are not shown. Here are two animation frames triggered from scroll events after this change:

![image](https://user-images.githubusercontent.com/2367265/50059002-e944b780-0135-11e9-952b-b2560b13e0c5.png)


