### PR TITLE
Add 'popper-active' class when the popper is shown

### DIFF
--- a/src/component/popper.js.vue
+++ b/src/component/popper.js.vue
@@ -79,7 +79,7 @@
 </style>
 
 <template>
-  <component :is="tagName">
+  <component :is="tagName" :class="{'popper-active': showPopper}">
     <transition :name="transition" :enter-active-class="enterActiveClass" :leave-active-class="leaveActiveClass" @after-leave="doDestroy">
       <span
         ref="popper"


### PR DESCRIPTION
Morning!

I found this great component and I decided to add a small piece of functionality for those who need:

- to know when popper is active so they can easily change the styling of the slot

By adding this 'popper-active' class I can easily customize my slot

e.g.:

```
<popper trigger="click">
    <div class="popper">
        <div class="avatar-container">
            <img src="https://cdn.iconscout.com/icon/free/png-256/avatar-380-456332.png"/>
        </div>
    </div>
    <div class="marker" slot="reference"></div>
</popper>
```

```
.popper-active {
  .marker {
    transform: scale(1.8);
  }
}
```

Please let me know what you think
