### PR TITLE
[MOBILE] Close popper on touchstart document

### DIFF
--- a/src/component/popper.js.vue
+++ b/src/component/popper.js.vue
@@ -239,11 +239,13 @@
         case 'clickToOpen':
           on(this.referenceElm, 'click', this.doShow);
           on(document, 'click', this.handleDocumentClick);
+          on(document, 'touchstart', this.handleDocumentClick);
           break;
         case 'click': // Same as clickToToggle, provided for backwards compatibility.
         case 'clickToToggle':
           on(this.referenceElm, 'click', this.doToggle);
           on(document, 'click', this.handleDocumentClick);
+          on(document, 'touchstart', this.handleDocumentClick);
           break;
         case 'hover':
           on(this.referenceElm, 'mouseover', this.onMouseOver);


### PR DESCRIPTION
Hello!

While working with this component a found the following bug:

When you use it on a horizontal scrollable container the tooltip follows you and cause a jitter on mobile. This is because we're not closing the tooltip on touchstart (#document) 

Thanks!